### PR TITLE
Bump version to 3.0.1 and export extensions for public access

### DIFF
--- a/feature_manager/CHANGELOG.md
+++ b/feature_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+- Export for `src/utils/extensions.dart `to make extensions publicly accessible.
+
 ## 3.0.0
 
 - Added a new wrapper for typed features. Instead of creating a generic Feature class, you can now use specific types: `BooleanFeature`, `TextFeature`, `IntegerFeature`, `DoubleFeature`, and `JsonFeature`.

--- a/feature_manager/lib/feature_manager.dart
+++ b/feature_manager/lib/feature_manager.dart
@@ -2,3 +2,4 @@ library;
 
 export 'src/feature_manager.dart';
 export 'src/presentation/features_screen.dart';
+export 'src/utils/extensions.dart';

--- a/feature_manager/pubspec.yaml
+++ b/feature_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: Feature manager for developer preferences and experiments
 repository: https://github.com/theRealGetman/feature-manager/tree/master/feature_manager
 issue_tracker: https://github.com/theRealGetman/feature-manager/issues
 
-version: 3.0.0
+version: 3.0.1
 
 environment:
   sdk: ">=3.2.4 <4.0.0"

--- a/generator/pubspec.lock
+++ b/generator/pubspec.lock
@@ -105,9 +105,10 @@ packages:
   feature_manager:
     dependency: "direct main"
     description:
-      path: "../feature_manager"
-      relative: true
-    source: path
+      name: feature_manager
+      sha256: "078a65bdfd0ca03d86215f03370ad0ed0f1bdc5fe2091e7bfe66f297e1613238"
+      url: "https://pub.dev"
+    source: hosted
     version: "3.0.0"
   ffi:
     dependency: transitive


### PR DESCRIPTION
This pull request adds support for exporting utility extensions to enhance feature management in the library. The extensions provide convenient methods for interacting with various Feature types, making retrieving feature values or checking their statuses directly easier.

## Details

1.	BooleanFeatureExt
	•	Adds a getter isEnabled to check if a boolean feature is enabled.
	•	Example:

```dart
if (someBooleanFeature.isEnabled) {
  // Do something
}
```

2.	DoubleFeatureExt
	•	Adds a getter value to retrieve the value of a double feature.
	•	Returns null if not set.
	•	Example:

```dart
double? featureValue = someDoubleFeature.value;
```

3. IntegerFeatureExt
	•	Adds a getter value to retrieve the value of an integer feature.
	•	Returns null if not set.
	•	Example:
```dart
int? featureValue = someIntegerFeature.value;
```

4.	TextFeatureExt
	•	Adds a getter value to retrieve the value of a text feature.
	•	Returns null if not set.
	•	Example:
```dart
String? featureValue = someTextFeature.value;
```

5. FeatureExt
	•	Adds a getter value to retrieve the value of a generic feature as an Object.
	•	Returns null if not set.
	•	Example:
```dart
Object? featureValue = someFeature.value;
```

Impact
- Improves developer experience by reducing boilerplate for feature interactions.
- Simplifies access to feature values across the library.