### PR TITLE
Fix Default Value Extraction in Code Generator for Non-String Types

### DIFF
--- a/example/lib/features.dart
+++ b/example/lib/features.dart
@@ -12,6 +12,7 @@ class AppFeatures {
     required this.doubleFeature,
     required this.integerFeature,
     required this.jsonFeature,
+    required this.nullableTextFeature,
   });
 
   factory AppFeatures.instance() => _$AppFeatures();
@@ -20,7 +21,7 @@ class AppFeatures {
     key: 'dev-prefs-text-pref',
     title: 'Text pref',
     description: 'This is text preference',
-    defaultValue: '',
+    defaultValue: 'Some default text',
     valueType: FeatureValueType.text,
   )
   final Feature textFeature;
@@ -38,7 +39,7 @@ class AppFeatures {
     key: 'dev-prefs-double-pref',
     title: 'Number double pref',
     description: 'This is number double preference',
-    defaultValue: null,
+    defaultValue: 2.2,
     valueType: FeatureValueType.doubleNumber,
   )
   final Feature doubleFeature;
@@ -47,7 +48,7 @@ class AppFeatures {
     key: 'dev-prefs-integer-pref',
     title: 'Number integer pref',
     description: 'This is number integer preference',
-    defaultValue: null,
+    defaultValue: 1,
     valueType: FeatureValueType.integerNumber,
   )
   final Feature integerFeature;
@@ -60,4 +61,13 @@ class AppFeatures {
     valueType: FeatureValueType.json,
   )
   final Feature jsonFeature;
+
+  @FeatureOptions(
+    key: 'dev-prefs-text-pref',
+    title: 'Text pref',
+    description: 'This is text preference',
+    defaultValue: null,
+    valueType: FeatureValueType.text,
+  )
+  final Feature nullableTextFeature;
 }

--- a/example/lib/features.fm.g.dart
+++ b/example/lib/features.fm.g.dart
@@ -16,31 +16,37 @@ class _$AppFeatures implements AppFeatures {
           key: 'dev-prefs-text-pref',
           title: 'Text pref',
           description: 'This is text preference',
-          defaultValue: '',
+          defaultValue: 'Some default text',
         ),
         booleanFeature = BooleanFeature(
           key: 'dev-prefs-bool-pref',
           title: 'Toggle pref',
           description: 'This is toggle preference',
-          defaultValue: null,
+          defaultValue: false,
         ),
         doubleFeature = DoubleFeature(
           key: 'dev-prefs-double-pref',
           title: 'Number double pref',
           description: 'This is number double preference',
-          defaultValue: null,
+          defaultValue: 2.2,
         ),
         integerFeature = IntegerFeature(
           key: 'dev-prefs-integer-pref',
           title: 'Number integer pref',
           description: 'This is number integer preference',
-          defaultValue: null,
+          defaultValue: 1,
         ),
         jsonFeature = JsonFeature(
           key: 'dev-prefs-json-pref',
           title: 'Json pref',
           description: 'This is json preference',
           defaultValue: '{value: \'Json default value\'}',
+        ),
+        nullableTextFeature = TextFeature(
+          key: 'dev-prefs-text-pref',
+          title: 'Text pref',
+          description: 'This is text preference',
+          defaultValue: null,
         );
   @override
   final TextFeature textFeature;
@@ -52,6 +58,8 @@ class _$AppFeatures implements AppFeatures {
   final IntegerFeature integerFeature;
   @override
   final JsonFeature jsonFeature;
+  @override
+  final TextFeature nullableTextFeature;
 }
 
 extension AppFeaturesExt on AppFeatures {
@@ -61,6 +69,7 @@ extension AppFeaturesExt on AppFeatures {
         doubleFeature,
         integerFeature,
         jsonFeature,
+        nullableTextFeature,
       ];
 }
 
@@ -70,4 +79,5 @@ extension FeatureManagerExt on FeatureManager {
   DoubleFeature get doubleFeature => _$AppFeatures().doubleFeature;
   IntegerFeature get integerFeature => _$AppFeatures().integerFeature;
   JsonFeature get jsonFeature => _$AppFeatures().jsonFeature;
+  TextFeature get nullableTextFeature => _$AppFeatures().nullableTextFeature;
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,11 +13,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-  feature_manager:
-    path: ../feature_manager
+  feature_manager: 3.0.1
 
   provider: ^6.1.2
-  shared_preferences: ^2.3.2
+  shared_preferences: ^2.3.3
 
 dev_dependencies:
   build_runner:

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+- Fixed: Default Value Extraction Issue
+
 ## 3.0.0
 
 - Initial version.

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:feature_manager/annotations.dart';
@@ -117,15 +118,42 @@ class FeatureGenerator extends GeneratorForAnnotation<FeatureManagerInit> {
       if (elementValue == null || !typeChecker.isExactlyType(elementValue.type!)) {
         continue;
       }
+
+      final defaultValueField = elementValue.getField('defaultValue');
+      final defaultValue = _getLiteralValue(defaultValueField);
+
       return FeatureOptions(
         key: elementValue.getField('key')?.toStringValue() ?? '',
         title: elementValue.getField('title')?.toStringValue() ?? '',
         description: elementValue.getField('description')?.toStringValue() ?? '',
-        defaultValue: elementValue.getField('defaultValue')?.toStringValue(),
+        defaultValue: defaultValue,
         valueType: FeatureValueType
             .values[elementValue.getField('valueType')?.getField('index')?.toIntValue() ?? 0],
       );
     }
+    return null;
+  }
+
+  dynamic _getLiteralValue(DartObject? object) {
+    if (object == null || object.isNull) {
+      return null;
+    }
+
+    final type = object.type;
+    if (type == null) {
+      return null;
+    }
+
+    if (type.isDartCoreString) {
+      return object.toStringValue();
+    } else if (type.isDartCoreInt) {
+      return object.toIntValue();
+    } else if (type.isDartCoreDouble) {
+      return object.toDoubleValue();
+    } else if (type.isDartCoreBool) {
+      return object.toBoolValue();
+    }
+    // Handle other types if necessary
     return null;
   }
 


### PR DESCRIPTION
This pull request addresses an issue where the defaultValue specified in the FeatureOptions annotation was always null when the value was of a type other than String. The problem was caused by the generator using .toStringValue() to extract the defaultValue, which only works for string literals.

## Changes Made:

**Updated _getFeatureOptions Method:**
- Introduced a new helper function _getLiteralValue(DartObject? object) to correctly extract the value of defaultValue regardless of its type.
- The `_getLiteralValue` function handles the following types: String, int, double, bool
- Modified the extraction of defaultValue to use _getLiteralValue:

```dart
final defaultValueField = elementValue.getField('defaultValue');
final defaultValue = _getLiteralValue(defaultValueField);
```
