### PR TITLE
Fix Generator to Include remoteSourceKey and type Parameters in Generated Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Feature Manager allows you to hide unfinished or secret features from your users
 
 If you want to use A/B testing or feature toggling with Firebase Remote Config, use [Remote Config Feature Manager](https://pub.dev/packages/remote_config_feature_manager)
 
-![Example 01](doc/feature-manager-1.png) ![Example 02](doc/feature-manager-2.png)
+| Example                                   | Developer Preferences                     |
+| ----------------------------------------- | ----------------------------------------- |
+| ![Example 01](/doc/feature-manager-1.png) | ![Example 02](/doc/feature-manager-2.png) |
 
 ## Getting Started
 
@@ -185,6 +187,7 @@ Navigator.of(context).push(
     ),
 );
 ```
+
 **Note**: Hide this screen or navigation option in production builds to prevent users from accessing development features.
 
 ### Feature parameters

--- a/example/lib/features.dart
+++ b/example/lib/features.dart
@@ -19,6 +19,7 @@ class AppFeatures {
 
   @FeatureOptions(
     key: 'dev-prefs-text-pref',
+    remoteSourceKey: 'REMOTE-KEY-dev-prefs-text-pref',
     title: 'Text pref',
     description: 'This is text preference',
     defaultValue: 'Some default text',

--- a/example/lib/features.fm.g.dart
+++ b/example/lib/features.fm.g.dart
@@ -14,39 +14,51 @@ class _$AppFeatures implements AppFeatures {
   _$AppFeatures._internal()
       : textFeature = TextFeature(
           key: 'dev-prefs-text-pref',
+          remoteSourceKey: 'REMOTE-KEY-dev-prefs-text-pref',
           title: 'Text pref',
           description: 'This is text preference',
           defaultValue: 'Some default text',
+          type: FeatureType.experiment,
         ),
         booleanFeature = BooleanFeature(
           key: 'dev-prefs-bool-pref',
+          remoteSourceKey: '',
           title: 'Toggle pref',
           description: 'This is toggle preference',
           defaultValue: false,
+          type: FeatureType.feature,
         ),
         doubleFeature = DoubleFeature(
           key: 'dev-prefs-double-pref',
+          remoteSourceKey: '',
           title: 'Number double pref',
           description: 'This is number double preference',
           defaultValue: 2.2,
+          type: FeatureType.feature,
         ),
         integerFeature = IntegerFeature(
           key: 'dev-prefs-integer-pref',
+          remoteSourceKey: '',
           title: 'Number integer pref',
           description: 'This is number integer preference',
           defaultValue: 1,
+          type: FeatureType.feature,
         ),
         jsonFeature = JsonFeature(
           key: 'dev-prefs-json-pref',
+          remoteSourceKey: '',
           title: 'Json pref',
           description: 'This is json preference',
           defaultValue: '{value: \'Json default value\'}',
+          type: FeatureType.feature,
         ),
         nullableTextFeature = TextFeature(
           key: 'dev-prefs-text-pref',
+          remoteSourceKey: '',
           title: 'Text pref',
           description: 'This is text preference',
           defaultValue: null,
+          type: FeatureType.feature,
         );
   @override
   final TextFeature textFeature;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  feature_manager: 3.0.1
+  feature_manager: 3.0.2
 
   provider: ^6.1.2
   shared_preferences: ^2.3.3
@@ -22,8 +22,7 @@ dev_dependencies:
   build_runner:
   flutter_test:
     sdk: flutter
-  feature_manager_generator:
-    path: ../generator/
+  feature_manager_generator: 3.0.2
 
 # The following section is specific to Flutter.
 flutter:

--- a/feature_manager/CHANGELOG.md
+++ b/feature_manager/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.2
+
+- Removed unused `value` Parameter from `FeatureOptions`:
+- Added `FeatureType` Parameter to Typed Feature Classes
+
 ## 3.0.1
 
 - Export for `src/utils/extensions.dart `to make extensions publicly accessible.

--- a/feature_manager/lib/src/annotations/annotations.dart
+++ b/feature_manager/lib/src/annotations/annotations.dart
@@ -12,7 +12,6 @@ class FeatureOptions {
     this.type = FeatureType.feature,
     this.description = '',
     this.remoteSourceKey = '',
-    this.value,
     this.defaultValue,
   });
 
@@ -22,6 +21,5 @@ class FeatureOptions {
   final String title;
   final String description;
   final String remoteSourceKey;
-  final Object? value;
   final Object? defaultValue;
 }

--- a/feature_manager/lib/src/models/feature.dart
+++ b/feature_manager/lib/src/models/feature.dart
@@ -8,6 +8,7 @@ class BooleanFeature extends Feature {
     super.remoteSourceKey,
     bool? super.value,
     bool? super.defaultValue,
+    super.type,
   }) : super(
           valueType: FeatureValueType.toggle,
         );
@@ -21,6 +22,7 @@ class TextFeature extends Feature {
     super.remoteSourceKey,
     String? super.value,
     String? super.defaultValue,
+    super.type,
   }) : super(
           valueType: FeatureValueType.text,
         );
@@ -34,6 +36,7 @@ class DoubleFeature extends Feature {
     super.remoteSourceKey,
     double? super.value,
     double? super.defaultValue,
+    super.type,
   }) : super(
           valueType: FeatureValueType.doubleNumber,
         );
@@ -47,6 +50,7 @@ class IntegerFeature extends Feature {
     super.remoteSourceKey,
     int? super.value,
     int? super.defaultValue,
+    super.type,
   }) : super(
           valueType: FeatureValueType.integerNumber,
         );
@@ -60,6 +64,7 @@ class JsonFeature extends Feature {
     super.remoteSourceKey,
     super.value,
     super.defaultValue,
+    super.type,
   }) : super(
           valueType: FeatureValueType.json,
         );

--- a/feature_manager/pubspec.yaml
+++ b/feature_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: Feature manager for developer preferences and experiments
 repository: https://github.com/theRealGetman/feature-manager/tree/master/feature_manager
 issue_tracker: https://github.com/theRealGetman/feature-manager/issues
 
-version: 3.0.1
+version: 3.0.2
 
 environment:
   sdk: ">=3.2.4 <4.0.0"

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.2
+
+- Fixed an issue where the `remoteSourceKey` parameter specified in FeatureOptions was not included in the generated code.
+- Fixed an issue where the `type` parameter in FeatureOptions, responsible for specifying the FeatureType, was not being generated.
+
 ## 3.0.1
 
 - Fixed: Default Value Extraction Issue

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -124,9 +124,12 @@ class FeatureGenerator extends GeneratorForAnnotation<FeatureManagerInit> {
 
       return FeatureOptions(
         key: elementValue.getField('key')?.toStringValue() ?? '',
+        remoteSourceKey: elementValue.getField('remoteSourceKey')?.toStringValue() ?? '',
         title: elementValue.getField('title')?.toStringValue() ?? '',
         description: elementValue.getField('description')?.toStringValue() ?? '',
         defaultValue: defaultValue,
+        type:
+            FeatureType.values[elementValue.getField('type')?.getField('index')?.toIntValue() ?? 0],
         valueType: FeatureValueType
             .values[elementValue.getField('valueType')?.getField('index')?.toIntValue() ?? 0],
       );
@@ -153,7 +156,6 @@ class FeatureGenerator extends GeneratorForAnnotation<FeatureManagerInit> {
     } else if (type.isDartCoreBool) {
       return object.toBoolValue();
     }
-    // Handle other types if necessary
     return null;
   }
 
@@ -161,9 +163,11 @@ class FeatureGenerator extends GeneratorForAnnotation<FeatureManagerInit> {
     return '''
         $fieldName = $featureType(
           key: '${options.key}',
+          remoteSourceKey: '${options.remoteSourceKey}',
           title: '${options.title}',
           description: '${options.description}',
           defaultValue: ${_formatDefaultValue(options.defaultValue)},
+          type: ${options.type},
         )''';
   }
 

--- a/generator/pubspec.lock
+++ b/generator/pubspec.lock
@@ -106,10 +106,10 @@ packages:
     dependency: "direct main"
     description:
       name: feature_manager
-      sha256: "078a65bdfd0ca03d86215f03370ad0ed0f1bdc5fe2091e7bfe66f297e1613238"
+      sha256: "33a5e6a3defd846b94f4802b32fbeddfd325b75bfebd09f88ca0bf8fdea8da0e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   ffi:
     dependency: transitive
     description:

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -3,7 +3,7 @@ description: Feature manager generator for developer preferences and experiments
 repository: https://github.com/theRealGetman/feature-manager/tree/master/generator
 issue_tracker: https://github.com/theRealGetman/feature-manager/issues
 
-version: 3.0.0
+version: 3.0.2
 
 environment:
   sdk: ">=3.2.4 <4.0.0"
@@ -13,7 +13,7 @@ dependencies:
   analyzer: ^6.7.0
   build: ^2.4.1
   source_gen: ^1.5.0
-  feature_manager: ^3.0.0
+  feature_manager: ^3.0.2
 
 dev_dependencies:
   lints: ^5.0.0


### PR DESCRIPTION
This pull request addresses issues where the remoteSourceKey and type parameters specified in the FeatureOptions annotations were not being included in the generated code. These parameters are essential for integrating features with remote data sources and categorizing them appropriately.

**Changes Made:**
1. Fixed remoteSourceKey Parameter Generation:
- Issue: The remoteSourceKey parameter was specified in the FeatureOptions annotation but was not generated in the feature classes.
- Solution: Updated the code generator to include the remoteSourceKey parameter when generating feature classes.
- Impact: Features can now correctly specify keys for remote data sources, enabling proper integration with remote configurations.

2. Fixed type Parameter Generation:
- Issue: The type parameter, responsible for specifying the FeatureType (e.g., FeatureType.feature, FeatureType.experiment), was not being generated.
- Solution: Modified the generator to include the type parameter in the generated code.
- Impact: Features now correctly include their specified FeatureType, allowing for accurate categorization and management of features and experiments.