### PR TITLE
chore: support analyzer 12.0.0

### DIFF
--- a/packages/feature_manager_generator/CHANGELOG.md
+++ b/packages/feature_manager_generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.0
+
+- **Dependencies**: Updated analyzer to support the latest major version
+  - analyzer: ^9.0.0 → ^12.0.0
+
 ## 4.0.0
 
 - **Breaking Change**: Migrated from Element2 API back to Element API for analyzer 9.0.0 compatibility

--- a/packages/feature_manager_generator/pubspec.lock
+++ b/packages/feature_manager_generator/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "99.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "12.1.0"
   args:
     dependency: transitive
     description:
@@ -45,18 +45,18 @@ packages:
     dependency: "direct main"
     description:
       name: build
-      sha256: c1668065e9ba04752570ad7e038288559d1e2ca5c6d0131c0f5f55e39e777413
+      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.6"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   cli_config:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.8"
   feature_manager:
     dependency: "direct main"
     description:
@@ -206,18 +206,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -403,10 +403,10 @@ packages:
     dependency: "direct main"
     description:
       name: source_gen
-      sha256: "07b277b67e0096c45196cbddddf2d8c6ffc49342e88bf31d460ce04605ddac75"
+      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.2.3"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -467,26 +467,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -568,5 +568,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/packages/feature_manager_generator/pubspec.yaml
+++ b/packages/feature_manager_generator/pubspec.yaml
@@ -3,13 +3,13 @@ description: Feature manager generator for developer preferences and experiments
 repository: https://github.com/thebedcoder/feature-manager/tree/master/packages/feature_manager_generator
 issue_tracker: https://github.com/thebedcoder/feature-manager/issues
 
-version: 4.0.0
+version: 4.1.0
 
 environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:  
-  analyzer: ^9.0.0
+  analyzer: ^12.0.0
   build: ^4.0.3
   source_gen: ^4.1.1
   feature_manager: ^4.0.0


### PR DESCRIPTION
## What
Bumps the `analyzer` dependency constraint in `feature_manager_generator` from `^9.0.0` to `^12.0.0` (resolves to 12.1.0) and bumps the package version to 4.1.0.

## Why
Keep the generator compatible with the latest analyzer major version.

## Testing
- `dart analyze` in `packages/feature_manager_generator` — no issues
- `dart pub run build_runner build --delete-conflicting-outputs` in `examples/feature_manager_example` — generated code unchanged and correct
- No source changes were required since the `Element` API used by the generator is unaffected by the analyzer 9 → 12 upgrade

## Checklist
- [x] Tests pass
- [x] No new warnings
- [x] Docs updated if behaviour changed (CHANGELOG.md)